### PR TITLE
Update pool options during its life time

### DIFF
--- a/src/Manager/Fixed.php
+++ b/src/Manager/Fixed.php
@@ -103,4 +103,9 @@ class Fixed implements ManagerInterface
             Info::IDLE => $count - $busy,
         ];
     }
+
+    public function setOptions(array $options)
+    {
+        $this->options = $options;
+    }
 }

--- a/src/Manager/Flexible.php
+++ b/src/Manager/Flexible.php
@@ -146,4 +146,9 @@ class Flexible implements ManagerInterface
             'idle' => $count - $busy,
         ];
     }
+
+    public function setOptions(array $options)
+    {
+        $this->options = $options;
+    }
 }

--- a/src/ManagerInterface.php
+++ b/src/ManagerInterface.php
@@ -51,4 +51,12 @@ interface ManagerInterface extends EventEmitterInterface
      * @return array
      */
     public function info();
+
+    /**
+     * Overwrite the current options
+     *
+     * @param array $options
+     * @return void
+     */
+    public function setOptions(array $options);
 }

--- a/src/Pool/Dummy.php
+++ b/src/Pool/Dummy.php
@@ -56,4 +56,8 @@ class Dummy implements PoolInterface
     {
         return [];
     }
+
+    public function setOption($key, $value)
+    {
+    }
 }

--- a/src/Pool/Fixed.php
+++ b/src/Pool/Fixed.php
@@ -130,4 +130,16 @@ class Fixed implements PoolInterface
             Info::SIZE  => $workers[Info::TOTAL],
         ];
     }
+
+    /**
+     * Override option
+     *
+     * @param $key
+     * @param $value
+     */
+    public function setOption($key, $value)
+    {
+        $this->options[$key] = $value;
+        $this->manager->setOptions($this->options);
+    }
 }

--- a/src/Pool/Flexible.php
+++ b/src/Pool/Flexible.php
@@ -161,4 +161,16 @@ class Flexible implements PoolInterface
             Info::SIZE  => $workers[Info::TOTAL],
         ];
     }
+
+    /**
+     * Override option
+     *
+     * @param $key
+     * @param $value
+     */
+    public function setOption($key, $value)
+    {
+        $this->options[$key] = $value;
+        $this->manager->setOptions($this->options);
+    }
 }

--- a/src/PoolInterface.php
+++ b/src/PoolInterface.php
@@ -43,4 +43,12 @@ interface PoolInterface extends PoolInfoInterface, EventEmitterInterface
      * @return mixed
      */
     public function terminate(Message $message, $timeout = 5, $signal = null);
+
+    /**
+     * Override option
+     *
+     * @param $key
+     * @param $value
+     */
+    public function setOption($key, $value);
 }

--- a/tests/Pool/FixedTest.php
+++ b/tests/Pool/FixedTest.php
@@ -3,10 +3,13 @@
 namespace WyriHaximus\React\Tests\ChildProcess\Pool\Pool;
 
 use Phake;
+use React\EventLoop\Factory as LoopFactory;
 use WyriHaximus\React\ChildProcess\Messenger\Messages\Factory;
 use WyriHaximus\React\ChildProcess\Pool\Info;
 use WyriHaximus\React\ChildProcess\Pool\Options;
 use WyriHaximus\React\ChildProcess\Pool\Factory\Fixed;
+use WyriHaximus\React\ChildProcess\Pool\Pool\Fixed as FixedPool;
+use WyriHaximus\React\ChildProcess\Pool\ProcessCollection\Single;
 use WyriHaximus\React\Tests\ChildProcess\Pool\TestCase;
 
 class FixedTest extends TestCase
@@ -139,5 +142,33 @@ class FixedTest extends TestCase
         $function($worker);
 
         Phake::verify($worker)->rpc($message);
+    }
+
+    public function testSetOption()
+    {
+        $manager = Phake::mock('WyriHaximus\React\ChildProcess\Pool\Manager\Fixed');
+        $options = [
+            Options::SIZE => 1337,
+            Options::MANAGER => $manager,
+        ];
+        $loop = LoopFactory::create();
+        $processCollection = new Single(function () {
+            return Phake::mock('React\ChildProcess\Process');
+        });
+        $pool = new FixedPool($processCollection, $loop, $options);
+        $pool->setOption('key', 'value');
+        $pool->setOption(Options::SIZE, 128);
+        Phake::inOrder(
+            Phake::verify($manager)->setOptions([
+                'key' => 'value',
+                Options::SIZE => 1337,
+                Options::MANAGER => $manager,
+            ]),
+            Phake::verify($manager)->setOptions([
+                'key' => 'value',
+                Options::SIZE => 128,
+                Options::MANAGER => $manager,
+            ])
+        );
     }
 }


### PR DESCRIPTION
A use case for this is scaling the amount of workers up and down when the load of the systems permit it.

- [ ] Update pool interface
- [ ] Update manager interface
- [ ] Update fixed pool
- [ ] Update flexible pool
- [ ] Update fixed manager
- [ ] Update flexible manager