### PR TITLE
Remove event listeners on pool/worker termination to remove circular references to callbacks

### DIFF
--- a/benchmark/memory.php
+++ b/benchmark/memory.php
@@ -37,6 +37,7 @@ Flexible::createFromClass('WyriHaximus\React\ChildProcess\Messenger\ReturnChild'
     $timer = $loop->addPeriodicTimer(0.0001, function () use (&$i, $messenger, &$timer, $loop) {
         if ($i >= I) {
             $loop->cancelTimer($timer);
+            $timer = null;
             $messenger->terminate();
 
             show_memory('Completed messaging');
@@ -61,6 +62,6 @@ $loop = null;
 
 show_memory('Removed loop');
 
-gc_collect_cycles();
+$cycles = gc_collect_cycles();
 
-show_memory('gc_collect_cycles');
+show_memory('gc_collect_cycles: ' . $cycles);

--- a/src/Pool/Fixed.php
+++ b/src/Pool/Fixed.php
@@ -119,6 +119,7 @@ class Fixed implements PoolInterface
         }
 
         return \WyriHaximus\React\timedPromise($this->loop, $timeout)->then(function () {
+            $this->manager->removeAllListeners();
             return $this->manager->terminate();
         });
     }

--- a/src/Pool/Flexible.php
+++ b/src/Pool/Flexible.php
@@ -149,6 +149,7 @@ class Flexible implements PoolInterface
         }
 
         return \WyriHaximus\React\timedPromise($this->loop, $timeout)->then(function () {
+            $this->manager->removeAllListeners();
             return $this->manager->terminate();
         });
     }

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -72,6 +72,7 @@ class Worker implements WorkerInterface
     {
         $this->busy = true;
         $this->emit('terminating', [$this]);
+        $this->messenger->removeAllListeners();
         return $this->messenger->softTerminate();
     }
 }


### PR DESCRIPTION
While tracking down memory growth on a long running process using ReactPHP Filesystem I came across the following circular reference that needs to be cleaned up by the GC. Results where seen in benchmark/memory.php

In a small test of 2500 invocations of RPC this reduced GC cycles from 137 to 0

